### PR TITLE
Update Limo to 1.0.7

### DIFF
--- a/io.github.limo_app.limo.json
+++ b/io.github.limo_app.limo.json
@@ -30,6 +30,7 @@
     "--filesystem=/mnt",
     "--filesystem=/media",
     "--filesystem=/run/media",
+    "--filesystem=home/.var/app/com.valvesoftware.Steam",
     "--talk-name=org.freedesktop.Flatpak",
     "--system-talk-name=org.freedesktop.UDisks2"
   ],
@@ -344,7 +345,7 @@
         {
           "type": "git",
           "url": "https://github.com/limo-app/limo.git",
-          "tag": "v1.0.6"
+          "tag": "v1.0.7"
         }
       ]
     }


### PR DESCRIPTION
This update adds filesystem access to *home/.var/app/com.valvesoftware.Steam* for the following reasons:
- Limo is mainly used for modding games, many of which are installed using Steam
- As Steam has around 2.9 million downloads on Flathub, it is likely that some Limo users will use the flatpak Steam version
- Steam stores some files which users may want to access, like installed games, in *~/.var/app/com.valvesoftware.Steam*
- Since Limo has access to the home directory by default, users may assume that this extends to the Steam directory, which it does not
